### PR TITLE
Use drupol/php-conventions for code-style and standards.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,8 +4,10 @@
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+.scrutinizer export-ignore
 .travis.yml export-ignore
 CHANGELOG.md export-ignore
+grumphp.yml.dist export-ignore
 LICENSE export-ignore
 phpspec.yml export-ignore
 README.md export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ before_script:
 script:
   - composer validate
   - composer update
-  # - bin/phpcs
-  - vendor/bin/phpspec run --no-code-generation
+  - composer grumphp
 
 install:
     - travis_retry composer install

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "phpunit/php-code-coverage": "^5.0 || ^6.0 || ^7.0"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^3.2",
+        "drupol/php-conventions": "^1",
         "scrutinizer/ocular": "^1"
     },
     "suggest": {
@@ -62,6 +62,7 @@
     },
     "minimum-stability": "stable",
     "scripts": {
+        "grumphp": "./vendor/bin/grumphp run",
         "scrutinizer": "./vendor/bin/ocular code-coverage:upload --format=php-clover build/coverage.xml"
     },
     "support": {

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -1,0 +1,9 @@
+imports:
+  - { resource: vendor/drupol/php-conventions/config/php71/grumphp.yml }
+
+parameters:
+  extra_tasks:
+    phpspec:
+      verbose: true
+      metadata:
+        priority: 3000

--- a/spec/CodeCoverageExtensionSpec.php
+++ b/spec/CodeCoverageExtensionSpec.php
@@ -1,55 +1,58 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\LeanPHP\PhpSpec\CodeCoverage;
 
+use LeanPHP\PhpSpec\CodeCoverage\CodeCoverageExtension;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\ServiceContainer\IndexedServiceContainer;
-use Prophecy\Argument;
-use LeanPHP\PhpSpec\CodeCoverage\CodeCoverageExtension;
 
 /**
  * @author Henrik Bjornskov
  */
 class CodeCoverageExtensionSpec extends ObjectBehavior
 {
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(CodeCoverageExtension::class);
     }
 
-    function it_should_use_html_format_by_default()
+    public function it_should_transform_format_into_array(): void
     {
-        $container = new IndexedServiceContainer;
+        $container = new IndexedServiceContainer();
+        $container->setParam('code_coverage', ['format' => 'html']);
+        $this->load($container);
+
+        $options = $container->get('code_coverage.options');
+
+        if ($options['format'] !== ['html']) {
+            throw new Exception('Default format is not transformed to an array');
+        }
+    }
+
+    public function it_should_use_html_format_by_default(): void
+    {
+        $container = new IndexedServiceContainer();
         $this->load($container, []);
 
         $options = $container->get('code_coverage.options');
+
         if ($options['format'] !== ['html']) {
-            throw new Exception("Default format is not html");
+            throw new Exception('Default format is not html');
         }
     }
 
-    function it_should_transform_format_into_array()
+    public function it_should_use_singular_output(): void
     {
-        $container = new IndexedServiceContainer;
-        $container->setParam('code_coverage', array('format' => 'html'));
+        $container = new IndexedServiceContainer();
+        $container->setParam('code_coverage', ['output' => 'test', 'format' => 'foo']);
         $this->load($container);
 
         $options = $container->get('code_coverage.options');
-        if ($options['format'] !== ['html']) {
-            throw new Exception("Default format is not transformed to an array");
-        }
 
-    }
-
-    function it_should_use_singular_output()
-    {
-        $container = new IndexedServiceContainer;
-        $container->setParam('code_coverage', array('output' => 'test', 'format' => 'foo'));
-        $this->load($container);
-
-        $options = $container->get('code_coverage.options');
-        if ($options['output'] !== ['foo' => 'test']) {
-            throw new Exception("Default format is not singular output");
+        if (['foo' => 'test'] !== $options['output']) {
+            throw new Exception('Default format is not singular output');
         }
     }
 }

--- a/spec/Exception/NoCoverageDriverAvailableExceptionSpec.php
+++ b/spec/Exception/NoCoverageDriverAvailableExceptionSpec.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\LeanPHP\PhpSpec\CodeCoverage\Exception;
 
-use PhpSpec\ObjectBehavior;
 use LeanPHP\PhpSpec\CodeCoverage\Exception\NoCoverageDriverAvailableException;
+use PhpSpec\ObjectBehavior;
 
 /**
  * @author Stéphane Hulard
  */
 class NoCoverageDriverAvailableExceptionSpec extends ObjectBehavior
 {
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldBeAnInstanceOf(\RuntimeException::class);
         $this->shouldHaveType(NoCoverageDriverAvailableException::class);

--- a/spec/Listener/CodeCoverageListenerSpec.php
+++ b/spec/Listener/CodeCoverageListenerSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\LeanPHP\PhpSpec\CodeCoverage\Listener;
 
 use PhpSpec\Console\ConsoleIO;
@@ -22,166 +24,164 @@ class CodeCoverageListenerSpec extends ObjectBehavior
      *
      * @see https://github.com/leanphp/phpspec-code-coverage/issues/19
      *
-    function let(ConsoleIO $io, CodeCoverage $coverage)
-    {
-        $this->beConstructedWith($io, $coverage, array());
-    }
-
-    function it_is_initializable()
-    {
-        $this->shouldHaveType('LeanPHP\PhpSpec\CodeCoverage\Listener\CodeCoverageListener');
-    }
-
-
-    function it_should_run_all_reports(
-        CodeCoverage $coverage,
-        Report\Clover $clover,
-        Report\PHP $php,
-        SuiteEvent $event,
-        ConsoleIO $io
-    ) {
-        $reports = array(
-            'clover' => $clover,
-            'php' =>  $php
-        );
-
-        $io->isVerbose()->willReturn(false);
-
-        $this->beConstructedWith($io, $coverage, $reports);
-        $this->setOptions(array(
-            'format' => array('clover', 'php'),
-            'output' => array(
-                'clover' => 'coverage.xml',
-                'php' => 'coverage.php'
-            )
-        ));
-
-        $clover->process($coverage, 'coverage.xml')->shouldBeCalled();
-        $php->process($coverage, 'coverage.php')->shouldBeCalled();
-
-        $this->afterSuite($event);
-    }
-
-    function it_should_color_output_text_report_by_default(
-        CodeCoverage $coverage,
-        Report\Text $text,
-        SuiteEvent $event,
-        ConsoleIO $io
-    ) {
-        $reports = array(
-            'text' => $text
-        );
-
-        $this->beConstructedWith($io, $coverage, $reports);
-        $this->setOptions(array(
-            'format' => 'text'
-        ));
-
-        $io->isVerbose()->willReturn(false);
-        $io->isDecorated()->willReturn(true);
-
-        $text->process($coverage, true)->willReturn('report');
-        $io->writeln('report')->shouldBeCalled();
-
-        $this->afterSuite($event);
-    }
-
-    function it_should_not_color_output_text_report_unless_specified(
-        CodeCoverage $coverage,
-        Report\Text $text,
-        SuiteEvent $event,
-        ConsoleIO $io
-    ) {
-        $reports = array(
-            'text' => $text
-        );
-
-        $this->beConstructedWith($io, $coverage, $reports);
-        $this->setOptions(array(
-            'format' => 'text'
-        ));
-
-        $io->isVerbose()->willReturn(false);
-        $io->isDecorated()->willReturn(false);
-
-        $text->process($coverage, false)->willReturn('report');
-        $io->writeln('report')->shouldBeCalled();
-
-        $this->afterSuite($event);
-    }
-
-    function it_should_output_html_report(
-        CodeCoverage $coverage,
-        Report\Html\Facade $html,
-        SuiteEvent $event,
-        ConsoleIO $io
-    ) {
-        $reports = array(
-            'html' => $html
-        );
-
-        $this->beConstructedWith($io, $coverage, $reports);
-        $this->setOptions(array(
-            'format' => 'html',
-            'output' => array('html' => 'coverage'),
-        ));
-
-        $io->isVerbose()->willReturn(false);
-        $io->writeln(Argument::any())->shouldNotBeCalled();
-
-
-        $html->process($coverage, 'coverage')->willReturn('report');
-
-        $this->afterSuite($event);
-    }
-
-    function it_should_provide_extra_output_in_verbose_mode(
-        CodeCoverage $coverage,
-        Report\Html\Facade $html,
-        SuiteEvent $event,
-        ConsoleIO $io
-    ) {
-        $reports = array(
-            'html' => $html,
-        );
-
-        $this->beConstructedWith($io, $coverage, $reports);
-        $this->setOptions(array(
-            'format' => 'html',
-            'output' => array('html' => 'coverage'),
-        ));
-
-        $io->isVerbose()->willReturn(true);
-        $io->writeln('')->shouldBeCalled();
-        $io->writeln('Generating code coverage report in html format ...')->shouldBeCalled();
-
-        $this->afterSuite($event);
-    }
-
-    function it_should_correctly_handle_black_listed_files_and_directories(
-        CodeCoverage $coverage,
-        SuiteEvent $event,
-        Filter $filter,
-        ConsoleIO $io
-    )
-    {
-        $this->beConstructedWith($io, $coverage, array());
-
-        $coverage->filter()->willReturn($filter);
-
-        $this->setOptions(array(
-            'whitelist' => array('src'),
-            'blacklist' => array('src/filter'),
-            'whitelist_files' => array('src/filter/whilelisted_file'),
-            'blacklist_files' => array('src/filtered_file')
-        ));
-
-        $filter->addDirectoryToWhitelist('src')->shouldBeCalled();
-        $filter->removeDirectoryFromWhitelist('src/filter')->shouldBeCalled();
-        $filter->addFileToWhitelist('src/filter/whilelisted_file')->shouldBeCalled();
-        $filter->removeFileFromWhitelist('src/filtered_file')->shouldBeCalled();
-
-        $this->beforeSuite($event);
-    }
-    */
+     * function let(ConsoleIO $io, CodeCoverage $coverage)
+     * {
+     * $this->beConstructedWith($io, $coverage, array());
+     * }
+     *
+     * function it_is_initializable()
+     * {
+     * $this->shouldHaveType('LeanPHP\PhpSpec\CodeCoverage\Listener\CodeCoverageListener');
+     * }
+     *
+     * function it_should_run_all_reports(
+     * CodeCoverage $coverage,
+     * Report\Clover $clover,
+     * Report\PHP $php,
+     * SuiteEvent $event,
+     * ConsoleIO $io
+     * ) {
+     * $reports = array(
+     * 'clover' => $clover,
+     * 'php' =>  $php
+     * );
+     *
+     * $io->isVerbose()->willReturn(false);
+     *
+     * $this->beConstructedWith($io, $coverage, $reports);
+     * $this->setOptions(array(
+     * 'format' => array('clover', 'php'),
+     * 'output' => array(
+     * 'clover' => 'coverage.xml',
+     * 'php' => 'coverage.php'
+     * )
+     * ));
+     *
+     * $clover->process($coverage, 'coverage.xml')->shouldBeCalled();
+     * $php->process($coverage, 'coverage.php')->shouldBeCalled();
+     *
+     * $this->afterSuite($event);
+     * }
+     *
+     * function it_should_color_output_text_report_by_default(
+     * CodeCoverage $coverage,
+     * Report\Text $text,
+     * SuiteEvent $event,
+     * ConsoleIO $io
+     * ) {
+     * $reports = array(
+     * 'text' => $text
+     * );
+     *
+     * $this->beConstructedWith($io, $coverage, $reports);
+     * $this->setOptions(array(
+     * 'format' => 'text'
+     * ));
+     *
+     * $io->isVerbose()->willReturn(false);
+     * $io->isDecorated()->willReturn(true);
+     *
+     * $text->process($coverage, true)->willReturn('report');
+     * $io->writeln('report')->shouldBeCalled();
+     *
+     * $this->afterSuite($event);
+     * }
+     *
+     * function it_should_not_color_output_text_report_unless_specified(
+     * CodeCoverage $coverage,
+     * Report\Text $text,
+     * SuiteEvent $event,
+     * ConsoleIO $io
+     * ) {
+     * $reports = array(
+     * 'text' => $text
+     * );
+     *
+     * $this->beConstructedWith($io, $coverage, $reports);
+     * $this->setOptions(array(
+     * 'format' => 'text'
+     * ));
+     *
+     * $io->isVerbose()->willReturn(false);
+     * $io->isDecorated()->willReturn(false);
+     *
+     * $text->process($coverage, false)->willReturn('report');
+     * $io->writeln('report')->shouldBeCalled();
+     *
+     * $this->afterSuite($event);
+     * }
+     *
+     * function it_should_output_html_report(
+     * CodeCoverage $coverage,
+     * Report\Html\Facade $html,
+     * SuiteEvent $event,
+     * ConsoleIO $io
+     * ) {
+     * $reports = array(
+     * 'html' => $html
+     * );
+     *
+     * $this->beConstructedWith($io, $coverage, $reports);
+     * $this->setOptions(array(
+     * 'format' => 'html',
+     * 'output' => array('html' => 'coverage'),
+     * ));
+     *
+     * $io->isVerbose()->willReturn(false);
+     * $io->writeln(Argument::any())->shouldNotBeCalled();
+     *
+     * $html->process($coverage, 'coverage')->willReturn('report');
+     *
+     * $this->afterSuite($event);
+     * }
+     *
+     * function it_should_provide_extra_output_in_verbose_mode(
+     * CodeCoverage $coverage,
+     * Report\Html\Facade $html,
+     * SuiteEvent $event,
+     * ConsoleIO $io
+     * ) {
+     * $reports = array(
+     * 'html' => $html,
+     * );
+     *
+     * $this->beConstructedWith($io, $coverage, $reports);
+     * $this->setOptions(array(
+     * 'format' => 'html',
+     * 'output' => array('html' => 'coverage'),
+     * ));
+     *
+     * $io->isVerbose()->willReturn(true);
+     * $io->writeln('')->shouldBeCalled();
+     * $io->writeln('Generating code coverage report in html format ...')->shouldBeCalled();
+     *
+     * $this->afterSuite($event);
+     * }
+     *
+     * function it_should_correctly_handle_black_listed_files_and_directories(
+     * CodeCoverage $coverage,
+     * SuiteEvent $event,
+     * Filter $filter,
+     * ConsoleIO $io
+     * )
+     * {
+     * $this->beConstructedWith($io, $coverage, array());
+     *
+     * $coverage->filter()->willReturn($filter);
+     *
+     * $this->setOptions(array(
+     * 'whitelist' => array('src'),
+     * 'blacklist' => array('src/filter'),
+     * 'whitelist_files' => array('src/filter/whilelisted_file'),
+     * 'blacklist_files' => array('src/filtered_file')
+     * ));
+     *
+     * $filter->addDirectoryToWhitelist('src')->shouldBeCalled();
+     * $filter->removeDirectoryFromWhitelist('src/filter')->shouldBeCalled();
+     * $filter->addFileToWhitelist('src/filter/whilelisted_file')->shouldBeCalled();
+     * $filter->removeFileFromWhitelist('src/filtered_file')->shouldBeCalled();
+     *
+     * $this->beforeSuite($event);
+     * }
+     */
 }

--- a/src/CodeCoverageExtension.php
+++ b/src/CodeCoverageExtension.php
@@ -1,17 +1,20 @@
 <?php
+
+declare(strict_types=1);
+
 /**
- * This file is part of the leanphp/phpspec-code-coverage package
+ * This file is part of the leanphp/phpspec-code-coverage package.
  *
  * @author ek9 <dev@ek9.co>
- *
  * @license MIT
  *
  * For the full copyright and license information, please see the LICENSE file
  * that was distributed with this source code.
- *
  */
+
 namespace LeanPHP\PhpSpec\CodeCoverage;
 
+use LeanPHP\PhpSpec\CodeCoverage\Exception\NoCoverageDriverAvailableException;
 use LeanPHP\PhpSpec\CodeCoverage\Listener\CodeCoverageListener;
 use PhpSpec\Extension;
 use PhpSpec\ServiceContainer;
@@ -20,35 +23,34 @@ use SebastianBergmann\CodeCoverage\Filter;
 use SebastianBergmann\CodeCoverage\Report;
 use SebastianBergmann\CodeCoverage\Version;
 use Symfony\Component\Console\Input\InputOption;
-use LeanPHP\PhpSpec\CodeCoverage\Exception\NoCoverageDriverAvailableException;
 
 /**
  * Injects Code Coverage Event Subscriber into the EventDispatcher.
- * The Subscriber will add Code Coverage information before each example
+ * The Subscriber will add Code Coverage information before each example.
  *
  * @author Henrik Bjornskov
  */
 class CodeCoverageExtension implements Extension
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    public function load(ServiceContainer $container, array $params = [])
+    public function load(ServiceContainer $container, array $params = []): void
     {
         foreach ($container->getByTag('console.commands') as $command) {
             $command->addOption('no-coverage', null, InputOption::VALUE_NONE, 'Skip code coverage generation');
         }
 
-        $container->define('code_coverage.filter', function () {
+        $container->define('code_coverage.filter', static function () {
             return new Filter();
         });
 
-        $container->define('code_coverage', function ($container) {
+        $container->define('code_coverage', static function ($container) {
             try {
                 $coverage = new CodeCoverage(null, $container->get('code_coverage.filter'));
             } catch (\RuntimeException $error) {
                 throw new NoCoverageDriverAvailableException(
-                    "There is no available coverage driver to be used.",
+                    'There is no available coverage driver to be used.',
                     0,
                     $error
                 );
@@ -57,28 +59,30 @@ class CodeCoverageExtension implements Extension
             return $coverage;
         });
 
-        $container->define('code_coverage.options', function ($container) use ($params) {
+        $container->define('code_coverage.options', static function ($container) use ($params) {
             $options = !empty($params) ? $params : $container->getParam('code_coverage');
 
             if (!isset($options['format'])) {
-                $options['format'] = array('html');
-            } elseif (!is_array($options['format'])) {
+                $options['format'] = ['html'];
+            } elseif (!\is_array($options['format'])) {
                 $options['format'] = (array) $options['format'];
             }
 
             if (isset($options['output'])) {
-                if (!is_array($options['output']) && count($options['format']) === 1) {
+                if (!\is_array($options['output']) && 1 === \count($options['format'])) {
                     $format = $options['format'][0];
-                    $options['output'] = array($format => $options['output']);
+                    $options['output'] = [$format => $options['output']];
                 }
             }
 
             if (!isset($options['show_uncovered_files'])) {
                 $options['show_uncovered_files'] = true;
             }
+
             if (!isset($options['lower_upper_bound'])) {
                 $options['lower_upper_bound'] = 35;
             }
+
             if (!isset($options['high_lower_bound'])) {
                 $options['high_lower_bound'] = 70;
             }
@@ -86,34 +90,42 @@ class CodeCoverageExtension implements Extension
             return $options;
         });
 
-        $container->define('code_coverage.reports', function ($container) {
+        $container->define('code_coverage.reports', static function ($container) {
             $options = $container->get('code_coverage.options');
 
-            $reports = array();
+            $reports = [];
+
             foreach ($options['format'] as $format) {
                 switch ($format) {
                     case 'clover':
                         $reports['clover'] = new Report\Clover();
+
                         break;
                     case 'php':
                         $reports['php'] = new Report\PHP();
+
                         break;
                     case 'text':
                         $reports['text'] = new Report\Text(
                             $options['lower_upper_bound'],
                             $options['high_lower_bound'],
                             $options['show_uncovered_files'],
-                            /* $showOnlySummary */ false
+                            /* $showOnlySummary */
+                            false
                         );
+
                         break;
                     case 'xml':
                         $reports['xml'] = new Report\Xml\Facade(Version::id());
+
                         break;
                     case 'crap4j':
                         $reports['crap4j'] = new Report\Crap4j();
+
                         break;
                     case 'html':
                         $reports['html'] = new Report\Html\Facade();
+
                         break;
                 }
             }
@@ -123,10 +135,10 @@ class CodeCoverageExtension implements Extension
             return $reports;
         });
 
-        $container->define('event_dispatcher.listeners.code_coverage', function ($container) {
-
+        $container->define('event_dispatcher.listeners.code_coverage', static function ($container) {
             $skipCoverage = false;
             $input = $container->get('console.input');
+
             if ($input->hasOption('no-coverage') && $input->getOption('no-coverage')) {
                 $skipCoverage = true;
             }
@@ -137,7 +149,7 @@ class CodeCoverageExtension implements Extension
                 $container->get('code_coverage.reports'),
                 $skipCoverage
             );
-            $listener->setOptions($container->getParam('code_coverage', array()));
+            $listener->setOptions($container->getParam('code_coverage', []));
 
             return $listener;
         }, ['event_dispatcher.listeners']);

--- a/src/Exception/NoCoverageDriverAvailableException.php
+++ b/src/Exception/NoCoverageDriverAvailableException.php
@@ -1,18 +1,20 @@
 <?php
+
+declare(strict_types=1);
+
 /**
- * This file is part of the leanphp/phpspec-code-coverage package
+ * This file is part of the leanphp/phpspec-code-coverage package.
  *
  * @author shulard <s.hulard@chstudio.fr>
- *
  * @license MIT
  *
  * For the full copyright and license information, please see the LICENSE file
  * that was distributed with this source code.
- *
  */
+
 namespace LeanPHP\PhpSpec\CodeCoverage\Exception;
 
-use \RuntimeException;
+use RuntimeException;
 
 /**
  * When PHPUnit/CodeCoverage trigger an exception which says that's no driver

--- a/src/Listener/CodeCoverageListener.php
+++ b/src/Listener/CodeCoverageListener.php
@@ -1,15 +1,17 @@
 <?php
+
+declare(strict_types=1);
+
 /**
- * This file is part of the leanphp/phpspec-code-coverage package
+ * This file is part of the leanphp/phpspec-code-coverage package.
  *
  * @author  ek9 <dev@ek9.co>
- *
  * @license MIT
  *
  * For the full copyright and license information, please see the LICENSE file
  * that was distributed with this source code.
- *
  */
+
 namespace LeanPHP\PhpSpec\CodeCoverage\Listener;
 
 use PhpSpec\Console\ConsoleIO;
@@ -25,83 +27,39 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class CodeCoverageListener implements EventSubscriberInterface
 {
     private $coverage;
-    private $reports;
+
     private $io;
+
     private $options;
+
+    private $reports;
+
+    /**
+     * @var bool
+     */
     private $skipCoverage;
 
     /**
      * @param ConsoleIO    $io
      * @param CodeCoverage $coverage
      * @param array        $reports
-     * @param boolean      $skipCoverage
+     * @param bool      $skipCoverage
      */
     public function __construct(ConsoleIO $io, CodeCoverage $coverage, array $reports, $skipCoverage = false)
     {
         $this->io = $io;
         $this->coverage = $coverage;
-        $this->reports  = $reports;
-        $this->options  = [
+        $this->reports = $reports;
+        $this->options = [
             'whitelist' => ['src', 'lib'],
             'blacklist' => ['test', 'vendor', 'spec'],
             'whitelist_files' => [],
             'blacklist_files' => [],
-            'output'    => ['html' => 'coverage'],
-            'format'    => ['html'],
+            'output' => ['html' => 'coverage'],
+            'format' => ['html'],
         ];
 
         $this->skipCoverage = $skipCoverage;
-    }
-
-    /**
-     * Note: We use array_map() instead of array_walk() because the latter expects
-     * the callback to take the value as the first and the index as the seconds parameter.
-     *
-     * @param SuiteEvent $event
-     */
-    public function beforeSuite(SuiteEvent $event) : void
-    {
-        if ($this->skipCoverage) {
-            return;
-        }
-
-        $filter = $this->coverage->filter();
-
-        array_map(
-            [$filter, 'addDirectoryToWhitelist'],
-            $this->options['whitelist']
-        );
-        array_map(
-            [$filter, 'removeDirectoryFromWhitelist'],
-            $this->options['blacklist']
-        );
-        array_map(
-            [$filter, 'addFileToWhitelist'],
-            $this->options['whitelist_files']
-        );
-        array_map(
-            [$filter, 'removeFileFromWhitelist'],
-            $this->options['blacklist_files']
-        );
-    }
-
-    /**
-     * @param ExampleEvent $event
-     */
-    public function beforeExample(ExampleEvent $event): void
-    {
-        if ($this->skipCoverage) {
-            return;
-        }
-
-        $example = $event->getExample();
-
-        $name = strtr('%spec%::%example%', [
-            '%spec%' => $example->getSpecification()->getClassReflection()->getName(),
-            '%example%' => $example->getFunctionReflection()->getName(),
-        ]);
-
-        $this->coverage->start($name);
     }
 
     /**
@@ -130,21 +88,91 @@ class CodeCoverageListener implements EventSubscriberInterface
         }
 
         if ($this->io && $this->io->isVerbose()) {
-            $this->io->writeln('');
+            $this->io->writeln();
         }
 
         foreach ($this->reports as $format => $report) {
             if ($this->io && $this->io->isVerbose()) {
-                $this->io->writeln(sprintf('Generating code coverage report in %s format ...', $format));
+                $this->io->writeln(\sprintf('Generating code coverage report in %s format ...', $format));
             }
 
             if ($report instanceof Report\Text) {
-                $output = $report->process($this->coverage, /* showColors */ $this->io->isDecorated());
-                $this->io->writeln($output);
+                $this->io->writeln(
+                    $report->process($this->coverage, $this->io->isDecorated())
+                );
             } else {
                 $report->process($this->coverage, $this->options['output'][$format]);
             }
         }
+    }
+
+    /**
+     * @param ExampleEvent $event
+     */
+    public function beforeExample(ExampleEvent $event): void
+    {
+        if ($this->skipCoverage) {
+            return;
+        }
+
+        $example = $event->getExample();
+
+        $name = null;
+
+        if (null !== $spec = $example->getSpecification()) {
+            $name = $spec->getClassReflection()->getName();
+        }
+
+        $name = \strtr('%spec%::%example%', [
+            '%spec%' => $name,
+            '%example%' => $example->getFunctionReflection()->getName(),
+        ]);
+
+        $this->coverage->start($name);
+    }
+
+    /**
+     * Note: We use array_map() instead of array_walk() because the latter expects
+     * the callback to take the value as the first and the index as the seconds parameter.
+     *
+     * @param SuiteEvent $event
+     */
+    public function beforeSuite(SuiteEvent $event): void
+    {
+        if ($this->skipCoverage) {
+            return;
+        }
+
+        $filter = $this->coverage->filter();
+
+        foreach ($this->options['whitelist'] as $option) {
+            $filter->addDirectoryToWhitelist($option);
+        }
+
+        foreach ($this->options['blacklist'] as $option) {
+            $filter->removeDirectoryFromWhitelist($option);
+        }
+
+        foreach ($this->options['whitelist_files'] as $option) {
+            $filter->addFilesToWhitelist($option);
+        }
+
+        foreach ($this->options['blacklist_files'] as $option) {
+            $filter->removeFileFromWhitelist($option);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'beforeExample' => ['beforeExample', -10],
+            'afterExample' => ['afterExample', -10],
+            'beforeSuite' => ['beforeSuite', -10],
+            'afterSuite' => ['afterSuite', -10],
+        ];
     }
 
     /**
@@ -153,18 +181,5 @@ class CodeCoverageListener implements EventSubscriberInterface
     public function setOptions(array $options): void
     {
         $this->options = $options + $this->options;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public static function getSubscribedEvents(): array
-    {
-        return [
-            'beforeExample' => ['beforeExample', -10],
-            'afterExample'  => ['afterExample', -10],
-            'beforeSuite'   => ['beforeSuite', -10],
-            'afterSuite'    => ['afterSuite', -10],
-        ];
     }
 }


### PR DESCRIPTION
This PR:

* [x] Uses Grumphp,
* [x] Update and normalize composer.json file,
* [x] Update code style and standards,
* [x] Update Travis configuration,
* [x] Update Scrutinizer configuration.

![image](https://user-images.githubusercontent.com/252042/65952131-b27c2b80-e441-11e9-9d75-2af91647cb89.png)

Tasks:
* [x] Decide which coding standard to use. PSR12 or PSR12 + custom rules.
* [x] Decide if we should we use Grumphp to have the same local tool that works on the CI as well