### PR TITLE
Introduce new root namespace: FriendsOfPhpSpec.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.3.1] - 2019-10-01
+
+- Update root namespace to `FriendsOfPhpSpec` but maintain a class alias to the
+  old one `LeanPHP`. The `LeanPHP` root namespace is now deprecated and will be
+  removed in v5.
+
 ## [4.3.0] - 2019-10-01
 
 **Note!** This version mark the new home of the project. It was forked from

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Enable extension by editing `phpspec.yml` of your project:
 
 ``` yaml
 extensions:
-  LeanPHP\PhpSpec\CodeCoverage\CodeCoverageExtension: ~
+  FriendsOfPhpSpec\PhpSpec\CodeCoverage\CodeCoverageExtension: ~
 ```
 
 This will sufficient to enable Code Coverage generation by using defaults
@@ -75,7 +75,7 @@ configuration file below has all of the [Configuration Options](#Options).
 extensions:
   # ... other extensions ...
   # friends-of-phpspec/phpspec-code-coverage
-  LeanPHP\PhpSpec\CodeCoverage\CodeCoverageExtension:
+  FriendsOfPhpSpec\PhpSpec\CodeCoverage\CodeCoverageExtension:
     # Specify a list of formats in which code coverage report should be
     # generated.
     # Default: [html]

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,10 @@
     "autoload": {
         "psr-4": {
             "FriendsOfPhpSpec\\PhpSpec\\CodeCoverage\\": "src/"
-        }
+        },
+        "files": [
+            "src/bootstrap.php"
+        ]
     },
     "minimum-stability": "stable",
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
     },
     "autoload": {
         "psr-4": {
-            "LeanPHP\\PhpSpec\\CodeCoverage\\": "src/"
+            "FriendsOfPhpSpec\\PhpSpec\\CodeCoverage\\": "src/"
         }
     },
     "minimum-stability": "stable",

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,13 +1,13 @@
 # phpspec.yml
-# leanphp/phpspec-code-coverage
+# friends-of-phpspec/phpspec-code-coverage
 formatter.name: pretty
 suites:
     default_suite:
-        namespace: LeanPHP\PhpSpec\CodeCoverage
-        psr4_prefix: LeanPHP\PhpSpec\CodeCoverage
+        namespace: FriendsOfPhpSpec\PhpSpec\CodeCoverage
+        psr4_prefix: FriendsOfPhpSpec\PhpSpec\CodeCoverage
 
 extensions:
-  LeanPHP\PhpSpec\CodeCoverage\CodeCoverageExtension:
+  FriendsOfPhpSpec\PhpSpec\CodeCoverage\CodeCoverageExtension:
     format:
       - html
       - clover

--- a/spec/CodeCoverageExtensionSpec.php
+++ b/spec/CodeCoverageExtensionSpec.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace spec\LeanPHP\PhpSpec\CodeCoverage;
+namespace spec\FriendsOfPhpSpec\PhpSpec\CodeCoverage;
 
-use LeanPHP\PhpSpec\CodeCoverage\CodeCoverageExtension;
+use FriendsOfPhpSpec\PhpSpec\CodeCoverage\CodeCoverageExtension;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\ServiceContainer\IndexedServiceContainer;
 

--- a/spec/Exception/NoCoverageDriverAvailableExceptionSpec.php
+++ b/spec/Exception/NoCoverageDriverAvailableExceptionSpec.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace spec\LeanPHP\PhpSpec\CodeCoverage\Exception;
+namespace spec\FriendsOfPhpSpec\PhpSpec\CodeCoverage\Exception;
 
-use LeanPHP\PhpSpec\CodeCoverage\Exception\NoCoverageDriverAvailableException;
+use FriendsOfPhpSpec\PhpSpec\CodeCoverage\Exception\NoCoverageDriverAvailableException;
 use PhpSpec\ObjectBehavior;
 
 /**

--- a/spec/Listener/CodeCoverageListenerSpec.php
+++ b/spec/Listener/CodeCoverageListenerSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace spec\LeanPHP\PhpSpec\CodeCoverage\Listener;
+namespace spec\FriendsOfPhpSpec\PhpSpec\CodeCoverage\Listener;
 
 use PhpSpec\Console\ConsoleIO;
 use PhpSpec\Event\SuiteEvent;

--- a/src/CodeCoverageExtension.php
+++ b/src/CodeCoverageExtension.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * This file is part of the leanphp/phpspec-code-coverage package.
+ * This file is part of the friends-of-phpspec/phpspec-code-coverage package.
  *
  * @author ek9 <dev@ek9.co>
  * @license MIT
@@ -12,10 +12,10 @@ declare(strict_types=1);
  * that was distributed with this source code.
  */
 
-namespace LeanPHP\PhpSpec\CodeCoverage;
+namespace FriendsOfPhpSpec\PhpSpec\CodeCoverage;
 
-use LeanPHP\PhpSpec\CodeCoverage\Exception\NoCoverageDriverAvailableException;
-use LeanPHP\PhpSpec\CodeCoverage\Listener\CodeCoverageListener;
+use FriendsOfPhpSpec\PhpSpec\CodeCoverage\Exception\NoCoverageDriverAvailableException;
+use FriendsOfPhpSpec\PhpSpec\CodeCoverage\Listener\CodeCoverageListener;
 use PhpSpec\Extension;
 use PhpSpec\ServiceContainer;
 use SebastianBergmann\CodeCoverage\CodeCoverage;

--- a/src/Exception/NoCoverageDriverAvailableException.php
+++ b/src/Exception/NoCoverageDriverAvailableException.php
@@ -3,16 +3,16 @@
 declare(strict_types=1);
 
 /**
- * This file is part of the leanphp/phpspec-code-coverage package.
+ * This file is part of the friends-of-phpspec/phpspec-code-coverage.
  *
- * @author shulard <s.hulard@chstudio.fr>
+ * @author  shulard <s.hulard@chstudio.fr>
  * @license MIT
  *
  * For the full copyright and license information, please see the LICENSE file
  * that was distributed with this source code.
  */
 
-namespace LeanPHP\PhpSpec\CodeCoverage\Exception;
+namespace FriendsOfPhpSpec\PhpSpec\CodeCoverage\Exception;
 
 use RuntimeException;
 

--- a/src/Listener/CodeCoverageListener.php
+++ b/src/Listener/CodeCoverageListener.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * This file is part of the leanphp/phpspec-code-coverage package.
+ * This file is part of the friends-of-phpspec/phpspec-code-coverage package.
  *
  * @author  ek9 <dev@ek9.co>
  * @license MIT
@@ -12,7 +12,7 @@ declare(strict_types=1);
  * that was distributed with this source code.
  */
 
-namespace LeanPHP\PhpSpec\CodeCoverage\Listener;
+namespace FriendsOfPhpSpec\PhpSpec\CodeCoverage\Listener;
 
 use PhpSpec\Console\ConsoleIO;
 use PhpSpec\Event\ExampleEvent;

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the friends-of-phpspec/phpspec-code-coverage package.
+ *
+ * @author  shulard <s.hulard@chstudio.fr>
+ * @license MIT
+ *
+ * For the full copyright and license information, please see the LICENSE file
+ * that was distributed with this source code.
+ */
+use FriendsOfPhpSpec\PhpSpec\CodeCoverage\CodeCoverageExtension;
+
+\class_alias(
+    CodeCoverageExtension::class,
+    'LeanPHP\PhpSpec\CodeCoverage\CodeCoverageExtension'
+);


### PR DESCRIPTION
Related to issue #13, since we moved to a new org, we need to move the root namespace too :smile:.

By the way this is not a breaking change, we maintain a class alias to the old root namespace for the extension class.