### PR TITLE
Add options to configure minimum coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ extensions:
     # Blacklist files for which code generation should NOT be done
     #blacklist_files:
       #- lib/bootstrap.php
+    #
+    # Minimum coverage required - will exit with a non-zero code if not met
+    # Default: no minimum
+    #minimum:
+      #lines: 50.00
+      #classes: 50.00
+      #methods: 50.00
+      #functions: 50.00
 ```
 
 ### Options

--- a/src/Listener/CodeCoverageListener.php
+++ b/src/Listener/CodeCoverageListener.php
@@ -89,6 +89,8 @@ class CodeCoverageListener implements EventSubscriberInterface
                 $report->process($this->coverage, $this->options['output'][$format]);
             }
         }
+
+        $this->checkMinimumCoveragePercent();
     }
 
     public function beforeExample(ExampleEvent $event): void
@@ -160,5 +162,55 @@ class CodeCoverageListener implements EventSubscriberInterface
     public function setOptions(array $options): void
     {
         $this->options = $options + $this->options;
+    }
+
+    /**
+     * @throws \Exception
+     */
+    private function checkMinimumCoveragePercent(): void
+    {
+        $report = $this->coverage->getReport();
+
+        $coverageMessage = '%s coverage is too low as specified by minimum configuration: %.2f%% expected, %.2f covered.';
+
+        $lineMinimum = $this->options['minimum']['lines'] ?? false;
+        if ($lineMinimum !== false && (string) $lineMinimum > $report->getLineExecutedPercent()) {
+            throw new \Exception(sprintf(
+                $coverageMessage,
+                'Line',
+                $lineMinimum,
+                $report->getLineExecutedPercent()
+            ));
+        }
+
+        $classMinimum = $this->options['minimum']['classes'] ?? false;
+        if ($classMinimum !== false && (string) $classMinimum > $report->getTestedClassesPercent()) {
+            throw new \Exception(sprintf(
+                $coverageMessage,
+                'Class',
+                $classMinimum,
+                $report->getTestedClassesPercent()
+            ));
+        }
+
+        $methodMinimum = $this->options['minimum']['methods'] ?? false;
+        if ($methodMinimum !== false && (string) $methodMinimum > $report->getTestedMethodsPercent()) {
+            throw new \Exception(sprintf(
+                $coverageMessage,
+                'Methods',
+                $methodMinimum,
+                $report->getTestedMethodsPercent()
+            ));
+        }
+
+        $functionsMinimum = $this->options['minimum']['functions'] ?? false;
+        if ($functionsMinimum !== false && (string) $functionsMinimum > $report->getTestedFunctionsPercent()) {
+            throw new \Exception(sprintf(
+                $coverageMessage,
+                'Functions',
+                $functionsMinimum,
+                $report->getTestedFunctionsPercent()
+            ));
+        }
     }
 }

--- a/src/Listener/CodeCoverageListener.php
+++ b/src/Listener/CodeCoverageListener.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace FriendsOfPhpSpec\PhpSpec\CodeCoverage\Listener;
 
+use Exception;
 use PhpSpec\Console\ConsoleIO;
 use PhpSpec\Event\ExampleEvent;
 use PhpSpec\Event\SuiteEvent;
@@ -165,17 +166,20 @@ class CodeCoverageListener implements EventSubscriberInterface
     }
 
     /**
-     * @throws \Exception
+     * @throws Exception
      */
     private function checkMinimumCoveragePercent(): void
     {
         $report = $this->coverage->getReport();
 
-        $coverageMessage = '%s coverage is too low as specified by minimum configuration: %.2f%% expected, %.2f covered.';
+        $coverageMessage = <<<'COVMSG'
+%s coverage is too low as specified by minimum configuration: %.2f%% expected, %.2f covered.
+COVMSG;
 
         $lineMinimum = $this->options['minimum']['lines'] ?? false;
-        if ($lineMinimum !== false && (string) $lineMinimum > $report->getLineExecutedPercent()) {
-            throw new \Exception(sprintf(
+
+        if (false !== $lineMinimum && (string) $lineMinimum > $report->getLineExecutedPercent()) {
+            throw new Exception(sprintf(
                 $coverageMessage,
                 'Line',
                 $lineMinimum,
@@ -184,8 +188,9 @@ class CodeCoverageListener implements EventSubscriberInterface
         }
 
         $classMinimum = $this->options['minimum']['classes'] ?? false;
-        if ($classMinimum !== false && (string) $classMinimum > $report->getTestedClassesPercent()) {
-            throw new \Exception(sprintf(
+
+        if (false !== $classMinimum && (string) $classMinimum > $report->getTestedClassesPercent()) {
+            throw new Exception(sprintf(
                 $coverageMessage,
                 'Class',
                 $classMinimum,
@@ -194,8 +199,9 @@ class CodeCoverageListener implements EventSubscriberInterface
         }
 
         $methodMinimum = $this->options['minimum']['methods'] ?? false;
-        if ($methodMinimum !== false && (string) $methodMinimum > $report->getTestedMethodsPercent()) {
-            throw new \Exception(sprintf(
+
+        if (false !== $methodMinimum && (string) $methodMinimum > $report->getTestedMethodsPercent()) {
+            throw new Exception(sprintf(
                 $coverageMessage,
                 'Methods',
                 $methodMinimum,
@@ -204,8 +210,9 @@ class CodeCoverageListener implements EventSubscriberInterface
         }
 
         $functionsMinimum = $this->options['minimum']['functions'] ?? false;
-        if ($functionsMinimum !== false && (string) $functionsMinimum > $report->getTestedFunctionsPercent()) {
-            throw new \Exception(sprintf(
+
+        if (false !== $functionsMinimum && (string) $functionsMinimum > $report->getTestedFunctionsPercent()) {
+            throw new Exception(sprintf(
                 $coverageMessage,
                 'Functions',
                 $functionsMinimum,


### PR DESCRIPTION
If minimum %age is not met then an exception is thrown after the reports are generated and process exits with non-zero code