### PR TITLE
Avoid starting/stopping the coverage driver for each spec.

### DIFF
--- a/src/CodeCoverageExtension.php
+++ b/src/CodeCoverageExtension.php
@@ -143,13 +143,17 @@ class CodeCoverageExtension implements Extension
             $skipCoverage = false;
             $input = $container->get('console.input');
 
+            $coverage = $container->get('code_coverage');
+
             if ($input->hasOption('no-coverage') && $input->getOption('no-coverage')) {
                 $skipCoverage = true;
+            } else {
+                $coverage->start(null);
             }
 
             $listener = new CodeCoverageListener(
                 $container->get('console.io'),
-                $container->get('code_coverage'),
+                $coverage,
                 $container->get('code_coverage.reports'),
                 $skipCoverage
             );

--- a/src/Listener/CodeCoverageListener.php
+++ b/src/Listener/CodeCoverageListener.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace FriendsOfPhpSpec\PhpSpec\CodeCoverage\Listener;
 
 use PhpSpec\Console\ConsoleIO;
-use PhpSpec\Event\ExampleEvent;
 use PhpSpec\Event\SuiteEvent;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Report;
@@ -68,15 +67,6 @@ class CodeCoverageListener implements EventSubscriberInterface
         $this->skipCoverage = $skipCoverage;
     }
 
-    public function afterExample(ExampleEvent $event): void
-    {
-        if ($this->skipCoverage) {
-            return;
-        }
-
-        $this->coverage->stop();
-    }
-
     public function afterSuite(SuiteEvent $event): void
     {
         if ($this->skipCoverage) {
@@ -104,28 +94,6 @@ class CodeCoverageListener implements EventSubscriberInterface
                 $report->process($this->coverage, $this->options['output'][$format]);
             }
         }
-    }
-
-    public function beforeExample(ExampleEvent $event): void
-    {
-        if ($this->skipCoverage) {
-            return;
-        }
-
-        $example = $event->getExample();
-
-        $name = null;
-
-        if (null !== $spec = $example->getSpecification()) {
-            $name = $spec->getClassReflection()->getName();
-        }
-
-        $name = strtr('%spec%::%example%', [
-            '%spec%' => $name,
-            '%example%' => $example->getFunctionReflection()->getName(),
-        ]);
-
-        $this->coverage->start($name);
     }
 
     /**
@@ -165,8 +133,6 @@ class CodeCoverageListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            'beforeExample' => ['beforeExample', -10],
-            'afterExample' => ['afterExample', -10],
             'beforeSuite' => ['beforeSuite', -10],
             'afterSuite' => ['afterSuite', -10],
         ];


### PR DESCRIPTION
Not sure it's the right thing to do but, since we know that the coverage is active or not just before registering the event listener.

We can start the coverage driver before launching the specs and until the final spec was executed.