### PR TITLE
Fix Travis CI tests with low deps

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,7 +15,7 @@ charset = utf-8
 indent_style = space
 indent_size = 4
 
-[*.{yml,yaml}]
+[*.{neon,yml,yaml}]
 indent_style = space
 indent_size = 2
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/bin/
-/build/
+/coverage/
 /composer.lock
 /vendor/

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,18 +1,18 @@
 build:
-    nodes:
-        analysis:
-            tests:
-                override:
-                    - php-scrutinizer-run
+  nodes:
+    analysis:
+      tests:
+        override:
+          - php-scrutinizer-run
 
 filter:
-    paths:
-        - 'src/*'
+  paths:
+    - 'src/*'
 
 tools:
-    external_code_coverage:
-        timeout: 600
-    php_loc: true
-    php_pdepend: true
-    php_sim: true
-    php_changetracking: true
+  external_code_coverage:
+    timeout: 600
+  php_loc: true
+  php_pdepend: true
+  php_sim: true
+  php_changetracking: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-matrix:
+jobs:
   include:
     - php: 7.1
     - php: 7.1
@@ -11,28 +11,26 @@ matrix:
     - php: 7.3
     - php: 7.3
       env: deps=low
+    - php: 7.4
+    - php: 7.4
+      env: deps=low
     - php: nightly
       env: deps=low
     - php: nightly
   allow_failures:
     - php: nightly
 
-depth: 1
-
 cache:
   directories:
-    - $HOME/.composer/cache/files
+    - $HOME/.composer/cache
 
-before_script:
-    - if [[ $deps = low ]]; then composer update --prefer-lowest --prefer-stable; fi
+install:
+  - travis_retry composer install --no-interaction
+  - if [[ $deps = low ]]; then travis_retry composer update --prefer-lowest --prefer-stable --no-interaction; fi
 
 script:
   - composer validate
-  - composer update
   - composer grumphp
-
-install:
-    - travis_retry composer install
 
 after_success:
   - phpenv config-rm xdebug.ini

--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,12 @@
     ],
     "require": {
         "php": "^7.1",
-        "phpspec/phpspec": "^4.2 || ^5.0 || ^6.0",
-        "phpunit/php-code-coverage": "^5.0 || ^6.0 || ^7.0"
+        "phpspec/phpspec": "^5.0 || ^6.0",
+        "phpunit/php-code-coverage": "^6.0 || ^7.0"
+    },
+    "conflict": {
+        "friendsofphp/php-cs-fixer": "2.16.0",
+        "sebastian/comparator": "<2.0"
     },
     "require-dev": {
         "drupol/php-conventions": "^1",
@@ -66,7 +70,7 @@
     "minimum-stability": "stable",
     "scripts": {
         "grumphp": "./vendor/bin/grumphp run",
-        "scrutinizer": "./vendor/bin/ocular code-coverage:upload --format=php-clover build/coverage.xml"
+        "scrutinizer": "./vendor/bin/ocular code-coverage:upload --format=php-clover coverage/clover.xml"
     },
     "support": {
         "issues": "https://github.com/friends-of-phpspec/phpspec-code-coverage/issues",

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -2,18 +2,15 @@
 # friends-of-phpspec/phpspec-code-coverage
 formatter.name: pretty
 suites:
-    default_suite:
-        namespace: FriendsOfPhpSpec\PhpSpec\CodeCoverage
-        psr4_prefix: FriendsOfPhpSpec\PhpSpec\CodeCoverage
+  default_suite:
+    namespace: FriendsOfPhpSpec\PhpSpec\CodeCoverage
+    psr4_prefix: FriendsOfPhpSpec\PhpSpec\CodeCoverage
 
 extensions:
   FriendsOfPhpSpec\PhpSpec\CodeCoverage\CodeCoverageExtension:
     format:
       - html
       - clover
-      - php
-      - text
     output:
-      html: build/coverage
-      clover: build/coverage.xml
-      php: build/coverage.php
+      html: coverage
+      clover: coverage/clover.xml

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,2 @@
+parameters:
+  checkMissingIterableValueType: false

--- a/spec/Listener/CodeCoverageListenerSpec.php
+++ b/spec/Listener/CodeCoverageListenerSpec.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace spec\FriendsOfPhpSpec\PhpSpec\CodeCoverage\Listener;
 
+use FriendsOfPhpSpec\PhpSpec\CodeCoverage\Listener\CodeCoverageListener;
 use PhpSpec\Console\ConsoleIO;
 use PhpSpec\Event\SuiteEvent;
 use PhpSpec\ObjectBehavior;
@@ -17,6 +18,16 @@ use SebastianBergmann\CodeCoverage\Report;
  */
 class CodeCoverageListenerSpec extends ObjectBehavior
 {
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(CodeCoverageListener::class);
+    }
+
+    public function let(ConsoleIO $io)
+    {
+        $this->beConstructedWith($io, new CodeCoverage(), []);
+    }
+
     /**
      * Disabled due to tests breaking as php-code-coverage marked their classes
      * final and we cannot mock them. The tests should be converted into proper

--- a/src/Listener/CodeCoverageListener.php
+++ b/src/Listener/CodeCoverageListener.php
@@ -26,14 +26,29 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class CodeCoverageListener implements EventSubscriberInterface
 {
+    /**
+     * @var CodeCoverage
+     */
     private $coverage;
 
+    /**
+     * @var ConsoleIO
+     */
     private $io;
 
+    /**
+     * @var array
+     */
     private $options;
 
+    /**
+     * @var array
+     */
     private $reports;
 
+    /**
+     * @var bool
+     */
     private $skipCoverage;
 
     public function __construct(ConsoleIO $io, CodeCoverage $coverage, array $reports, bool $skipCoverage = false)
@@ -65,19 +80,19 @@ class CodeCoverageListener implements EventSubscriberInterface
     public function afterSuite(SuiteEvent $event): void
     {
         if ($this->skipCoverage) {
-            if ($this->io && $this->io->isVerbose()) {
+            if ($this->io->isVerbose()) {
                 $this->io->writeln('Skipping code coverage generation');
             }
 
             return;
         }
 
-        if ($this->io && $this->io->isVerbose()) {
+        if ($this->io->isVerbose()) {
             $this->io->writeln();
         }
 
         foreach ($this->reports as $format => $report) {
-            if ($this->io && $this->io->isVerbose()) {
+            if ($this->io->isVerbose()) {
                 $this->io->writeln(sprintf('Generating code coverage report in %s format ...', $format));
             }
 


### PR DESCRIPTION
Until now, the low deps test was useless because
we always executed a `composer update` afterwards,
which updated all installed low-deps packages to
its latest version.

Relates to #21