### PR TITLE
Link build badge to travis-ci.com website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-phpspec-code-coverage
-=====================
+# phpspec-code-coverage
+
 [![Latest Stable Version](https://img.shields.io/packagist/v/friends-of-phpspec/phpspec-code-coverage.svg?style=flat-square)](https://packagist.org/packages/friends-of-phpspec/phpspec-code-coverage)
 [![Total Downloads](https://img.shields.io/packagist/dt/friends-of-phpspec/phpspec-code-coverage.svg?style=flat-square)](https://packagist.org/packages/friends-of-phpspec/phpspec-code-coverage)
 [![Scrutinizer Code
 Quality](https://img.shields.io/scrutinizer/quality/g/friends-of-phpspec/phpspec-code-coverage/master?style=flat-square)](https://scrutinizer-ci.com/g/friends-of-phpspec/phpspec-code-coverage/?branch=master)
-[![Travis](https://img.shields.io/travis/com/friends-of-phpspec/phpspec-code-coverage.svg?style=flat-square)](https://travis-ci.org/friends-of-phpspec/phpspec-code-coverage)
+[![Travis](https://img.shields.io/travis/com/friends-of-phpspec/phpspec-code-coverage.svg?style=flat-square)](https://travis-ci.com/friends-of-phpspec/phpspec-code-coverage)
 
 [phpspec-code-coverage][0] is a [PhpSpec][2] extension that generates Code
 Coverage reports for [PhpSpec][2] tests.


### PR DESCRIPTION
The repository was migrated from travis-ci.org to travis-ci.com:
https://docs.travis-ci.com/user/migrate/open-source-repository-migration/

Current link: https://travis-ci.org/friends-of-phpspec/phpspec-code-coverage

New link: https://travis-ci.com/friends-of-phpspec/phpspec-code-coverage