### PR TITLE
Support "phpunit/php-code-coverage" v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "require": {
         "php": ">= 7.1.3",
         "phpspec/phpspec": "^5.0 || ^6.0",
-        "phpunit/php-code-coverage": "^6.0 || ^7.0"
+        "phpunit/php-code-coverage": "^6.0 || ^7.0 || ^8.0"
     },
     "conflict": {
         "sebastian/comparator": "< 2.0"


### PR DESCRIPTION
Adds support for https://github.com/sebastianbergmann/php-code-coverage version 8.

Breaking change was dropping of PHP 7.2 support: https://github.com/sebastianbergmann/php-code-coverage/blob/8.0.2/ChangeLog.md