### PR TITLE
Bump up requirements to PHP >=7.2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macOS-latest]
-        php-versions: ['7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.2', '7.3', '7.4']
 
     steps:
       - name: Set git to use LF

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         }
     ],
     "require": {
-        "php": ">= 7.1.3",
+        "php": ">= 7.2",
         "phpspec/phpspec": "^5.0 || ^6.0",
         "phpunit/php-code-coverage": "^6.0 || ^7.0 || ^8.0"
     },


### PR DESCRIPTION
GrumPHP is not compatible with both Composer 2 and PHP 7.1. I think it's the time to let PHP 7.1 go and focus on more recent releases. This will unlock #35.