### PR TITLE
Exposes Code coverage optional arguments for directory filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ extensions:
     whitelist:
       - src
       - lib
+      # or to apply filtering on files names
+      #- directory: src
+      #  suffix: "Controller.php"
+      #  prefix: "Get"
     #
     # Whiltelist files for which code generation should be done
     # Default: empty
@@ -137,6 +141,10 @@ extensions:
     # Blacklist directories for which code generation should NOT be done
     #blacklist:
       #- src/legacy
+      # or to apply filtering on files names
+      #- directory: src/legacy
+      #  suffix: "Spec.php"
+      #  prefix: "Test"
     #
     # Blacklist files for which code generation should NOT be done
     #blacklist_files:
@@ -161,10 +169,12 @@ extensions:
 * `high_lower_bound` (optional) sets high lower bound for code coverage
   (default `70`)
 * `whitelist` takes an array of directories to whitelist (default: `lib`,
-  `src`).
+  `src`). The array can be made more specific if an associative array is 
+  given with the following keys (`directory`, `prefix`, `suffix`)
 * `whitelist_files` takes an array of files to whitelist (default: none).
 * `blacklist` takes an array of directories to blacklist (default: `test,
-  vendor, spec`)
+  vendor, spec`). The array can be made more specific if an associative 
+  array is given with the following keys (`directory`, `prefix`, `suffix`)
 * `blacklist_files` takes an array of files to blacklist
 
 ## Authors

--- a/spec/Exception/ConfigurationExceptionSpec.php
+++ b/spec/Exception/ConfigurationExceptionSpec.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\FriendsOfPhpSpec\PhpSpec\CodeCoverage\Exception;
+
+use FriendsOfPhpSpec\PhpSpec\CodeCoverage\Exception\ConfigurationException;
+use InvalidArgumentException;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @author Ignace Nyamagana Butera
+ */
+class ConfigurationExceptionSpec extends ObjectBehavior
+{
+    public function it_is_initializable(): void
+    {
+        $this->shouldBeAnInstanceOf(InvalidArgumentException::class);
+        $this->shouldHaveType(ConfigurationException::class);
+    }
+}

--- a/spec/Listener/CodeCoverageListenerSpec.php
+++ b/spec/Listener/CodeCoverageListenerSpec.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace spec\FriendsOfPhpSpec\PhpSpec\CodeCoverage\Listener;
 
+use FriendsOfPhpSpec\PhpSpec\CodeCoverage\Exception\ConfigurationException;
 use FriendsOfPhpSpec\PhpSpec\CodeCoverage\Listener\CodeCoverageListener;
-use InvalidArgumentException;
 use PhpSpec\Console\ConsoleIO;
 use PhpSpec\Event\SuiteEvent;
 use PhpSpec\ObjectBehavior;
@@ -14,8 +14,6 @@ use SebastianBergmann\CodeCoverage\Driver\Driver;
 use SebastianBergmann\CodeCoverage\Filter;
 use SebastianBergmann\CodeCoverage\RawCodeCoverageData;
 use stdClass;
-use Throwable;
-use TypeError;
 
 /**
  * Disabled due to tests breaking as php-code-coverage marked their classes
@@ -40,7 +38,7 @@ class CodeCoverageListenerSpec extends ObjectBehavior
         ]);
 
         $this
-            ->shouldNotThrow(TypeError::class)
+            ->shouldNotThrow(ConfigurationException::class)
             ->during('beforeSuite', [$event]);
     }
 
@@ -58,7 +56,7 @@ class CodeCoverageListenerSpec extends ObjectBehavior
         ]);
 
         $this
-            ->shouldNotThrow(Throwable::class)
+            ->shouldNotThrow(ConfigurationException::class)
             ->during('beforeSuite', [$event]);
     }
 
@@ -71,7 +69,7 @@ class CodeCoverageListenerSpec extends ObjectBehavior
         ]);
 
         $this
-            ->shouldThrow(TypeError::class)
+            ->shouldThrow(ConfigurationException::class)
             ->during('beforeSuite', [$event]);
     }
 
@@ -84,7 +82,7 @@ class CodeCoverageListenerSpec extends ObjectBehavior
         ]);
 
         $this
-            ->shouldThrow(InvalidArgumentException::class)
+            ->shouldThrow(ConfigurationException::class)
             ->during('beforeSuite', [$event]);
     }
 

--- a/src/Exception/ConfigurationException.php
+++ b/src/Exception/ConfigurationException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FriendsOfPhpSpec\PhpSpec\CodeCoverage\Exception;
+
+use InvalidArgumentException;
+
+class ConfigurationException extends InvalidArgumentException
+{
+}

--- a/src/Listener/CodeCoverageListener.php
+++ b/src/Listener/CodeCoverageListener.php
@@ -21,6 +21,8 @@ use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Report;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
+use function is_string;
+
 /**
  * @author Henrik Bjornskov
  */
@@ -146,11 +148,19 @@ class CodeCoverageListener implements EventSubscriberInterface
         $filter = $this->coverage->filter();
 
         foreach ($this->options['whitelist'] as $option) {
-            $filter->includeDirectory($option);
+            if (is_string($option)) {
+                $option = ['directory' => $option];
+            }
+            $option = $option + ['suffix' => '.php', 'prefix' => ''];
+            $filter->includeDirectory($option['directory'], $option['suffix'], $option['prefix']);
         }
 
         foreach ($this->options['blacklist'] as $option) {
-            $filter->excludeDirectory($option);
+            if (is_string($option)) {
+                $option = ['directory' => $option];
+            }
+            $option = $option + ['suffix' => '.php', 'prefix' => ''];
+            $filter->excludeDirectory($option['directory'], $option['suffix'], $option['prefix']);
         }
 
         $filter->includeFiles($this->options['whitelist_files']);

--- a/src/Listener/CodeCoverageListener.php
+++ b/src/Listener/CodeCoverageListener.php
@@ -14,14 +14,13 @@ declare(strict_types=1);
 
 namespace FriendsOfPhpSpec\PhpSpec\CodeCoverage\Listener;
 
-use InvalidArgumentException;
+use FriendsOfPhpSpec\PhpSpec\CodeCoverage\Exception\ConfigurationException;
 use PhpSpec\Console\ConsoleIO;
 use PhpSpec\Event\ExampleEvent;
 use PhpSpec\Event\SuiteEvent;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Report;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use TypeError;
 
 use function gettype;
 use function is_array;
@@ -203,14 +202,14 @@ class CodeCoverageListener implements EventSubscriberInterface
         }
 
         if (!is_array($option)) {
-            throw new TypeError(sprintf(
+            throw new ConfigurationException(sprintf(
                 'Directory filtering options must be a string or an associated array, %s given instead.',
                 gettype($option)
             ));
         }
 
         if (!isset($option['directory'])) {
-            throw new InvalidArgumentException('Missing required directory path.');
+            throw new ConfigurationException('Missing required directory path.');
         }
 
         return [


### PR DESCRIPTION
The goal of this PR is to better expose Code coverage option on directory exclusion or inclusion.
Currently this package only allows including or excluding full directories whereas the code coverage package enables excluding/including directories files based on directory but also, file suffixes and/or prefixes.

This PR exposes code coverage feature without introducing a BC break. The current setup is still possible but with this patch you can opt-in to use the new behaviour by using an array instead of a single string as shown below. Which simplify code coverage configuration.


```diff
formatter.name: pretty
suites:
    core:
        namespace: Bakame\Specification
        spec_prefix: null
        spec_path: src
        psr4_prefix: Bakame\Specification
extensions:
  FriendsOfPhpSpec\PhpSpec\CodeCoverage\CodeCoverageExtension:
    format:
      - html
    output: "build/coverage"
+    blacklist:
+      - directory: src
+        suffix: "Spec.php"
-    blacklist_files:
-      - "src/AllSpec.php"
-      - "src/AnySpec.php"
-      - "src/NoneSpec.php"
-      - "src/SpecificationsSpec.php"
  ```
