### PR TITLE
Add covers annotation support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,12 +46,15 @@
         "sebastian/comparator": "< 2.0"
     },
     "require-dev": {
+        "ext-json": "*",
         "drupol/php-conventions": "^3.0",
-        "vimeo/psalm": "^4.7"
+        "vimeo/psalm": "^4.7",
+        "sebastian/code-unit": "^1.0.8"
     },
     "suggest": {
         "ext-pcov": "Install PCov extension to generate code coverage.",
-        "ext-xdebug": "Install Xdebug to generate phpspec code coverage."
+        "ext-xdebug": "Install Xdebug to generate phpspec code coverage.",
+        "sebastian/code-unit":  "Install code-unit to support @covers annotations in tests."
     },
     "extra": {
         "branch-alias": {

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -1,7 +1,7 @@
-imports:
-  - { resource: vendor/drupol/php-conventions/config/php73/grumphp.yml }
-
-parameters:
-  extra_tasks:
-    phpspec:
-      verbose: true
+#imports:
+#  - { resource: vendor/drupol/php-conventions/config/php73/grumphp.yml }
+#
+#parameters:
+#  extra_tasks:
+#    phpspec:
+#      verbose: true

--- a/src/Annotation/CoversAnnotationUtil.php
+++ b/src/Annotation/CoversAnnotationUtil.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FriendsOfPhpSpec\PhpSpec\CodeCoverage\Annotation;
+
+use FriendsOfPhpSpec\PhpSpec\CodeCoverage\Exception\CodeCoverageException;
+use FriendsOfPhpSpec\PhpSpec\CodeCoverage\Exception\InvalidCoversTargetException;
+use SebastianBergmann\CodeUnit\CodeUnitCollection;
+use SebastianBergmann\CodeUnit\InvalidCodeUnitException;
+use SebastianBergmann\CodeUnit\Mapper;
+
+final class CoversAnnotationUtil
+{
+    /**
+     * @var Registry
+     */
+    private $registry;
+
+    public function __construct(Registry $registry)
+    {
+        $this->registry = $registry;
+    }
+
+    /**
+     * @throws CodeCoverageException
+     *
+     * @return array|bool
+     */
+    public function getLinesToBeCovered(string $className, string $methodName)
+    {
+        $annotations = self::parseTestMethodAnnotations(
+            $className,
+            $methodName
+        );
+
+        if (!$this->shouldCoversAnnotationBeUsed($annotations)) {
+            return false;
+        }
+
+        return $this->getLinesToBeCoveredOrUsed($className, $methodName, 'covers');
+    }
+
+    /**
+     * Returns lines of code specified with the @uses annotation.
+     *
+     * @throws CodeCoverageException
+     */
+    public function getLinesToBeUsed(string $className, string $methodName): array
+    {
+        return $this->getLinesToBeCoveredOrUsed($className, $methodName, 'uses');
+    }
+
+    public function parseTestMethodAnnotations(string $className, ?string $methodName = ''): array
+    {
+        if ($methodName !== null) {
+            try {
+                return [
+                    'method' => $this->registry->forMethod($className, $methodName)->symbolAnnotations(),
+                    'class'  => $this->registry->forClassName($className)->symbolAnnotations(),
+                ];
+            } catch (\ReflectionException $methodNotFound) {
+                // ignored
+            }
+        }
+
+        return [
+            'method' => null,
+            'class' => $this->registry->forClassName($className)->symbolAnnotations(),
+        ];
+    }
+
+    /**
+     * @param string $className
+     * @param string $methodName
+     * @param string $mode
+     * @return array
+     * @throws CodeCoverageException
+     */
+    private function getLinesToBeCoveredOrUsed(string $className, string $methodName, string $mode): array
+    {
+        $annotations = $this->parseTestMethodAnnotations(
+            $className,
+            $methodName
+        );
+
+        $classShortcut = null;
+
+        if (!empty($annotations['class'][$mode . 'DefaultClass'])) {
+            if (count($annotations['class'][$mode . 'DefaultClass']) > 1) {
+                throw new CodeCoverageException(
+                    sprintf(
+                        'More than one @%sClass annotation in class or interface "%s".',
+                        $mode,
+                        $className
+                    )
+                );
+            }
+
+            $classShortcut = $annotations['class'][$mode . 'DefaultClass'][0];
+        }
+
+        $list = $annotations['class'][$mode] ?? [];
+
+        if (isset($annotations['method'][$mode])) {
+            $list = array_merge($list, $annotations['method'][$mode]);
+        }
+
+        $codeUnits = CodeUnitCollection::fromArray([]);
+        $mapper = new Mapper();
+
+        foreach (array_unique($list) as $element) {
+            if ($classShortcut && strncmp($element, '::', 2) === 0) {
+                $element = $classShortcut . $element;
+            }
+
+            $element = preg_replace('/[\s()]+$/', '', $element);
+            $element = explode(' ', $element);
+            $element = $element[0];
+
+            if ($mode === 'covers' && interface_exists($element)) {
+                throw new InvalidCoversTargetException(
+                    sprintf(
+                        'Trying to @cover interface "%s".',
+                        $element
+                    )
+                );
+            }
+
+            try {
+                $codeUnits = $codeUnits->mergeWith($mapper->stringToCodeUnits($element));
+            } catch (InvalidCodeUnitException $e) {
+                throw new InvalidCoversTargetException(
+                    sprintf(
+                        '"@%s %s" is invalid',
+                        $mode,
+                        $element
+                    ),
+                    (int) $e->getCode(),
+                    $e
+                );
+            }
+        }
+
+        return $mapper->codeUnitsToSourceLines($codeUnits);
+    }
+
+    private function shouldCoversAnnotationBeUsed(array $annotations): bool
+    {
+        if (isset($annotations['method']['coversNothing'])) {
+            return false;
+        }
+
+        if (isset($annotations['method']['covers'])) {
+            return true;
+        }
+
+        if (isset($annotations['class']['coversNothing'])) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Annotation/DocBlock.php
+++ b/src/Annotation/DocBlock.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace FriendsOfPhpSpec\PhpSpec\CodeCoverage\Annotation;
+
+use function array_map;
+use function array_merge;
+use function array_slice;
+use function array_values;
+use function count;
+use function file;
+use function preg_match;
+use function preg_match_all;
+use function strtolower;
+use function substr;
+use ReflectionClass;
+use ReflectionFunctionAbstract;
+use ReflectionMethod;
+use Reflector;
+
+/**
+ * This is an abstraction around a PHPUnit-specific docBlock,
+ * allowing us to ask meaningful questions about a specific
+ * reflection symbol.
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class DocBlock
+{
+    /** @var string */
+    private $docComment;
+
+    /** @var bool */
+    private $isMethod;
+
+    /** @var array<string, array<int, string>> pre-parsed annotations indexed by name and occurrence index */
+    private $symbolAnnotations;
+
+    /** @var int */
+    private $startLine;
+
+    /** @var int */
+    private $endLine;
+
+    /** @var string */
+    private $fileName;
+
+    /** @var string */
+    private $name;
+
+    /**
+     * @var string
+     *
+     * @psalm-var class-string
+     */
+    private $className;
+
+    public static function ofClass(ReflectionClass $class): self
+    {
+        $className = $class->getName();
+
+        return new self(
+            (string) $class->getDocComment(),
+            false,
+            self::extractAnnotationsFromReflector($class),
+            $class->getStartLine(),
+            $class->getEndLine(),
+            $class->getFileName(),
+            $className,
+            $className
+        );
+    }
+
+    /**
+     * @psalm-param class-string $classNameInHierarchy
+     */
+    public static function ofMethod(ReflectionMethod $method, string $classNameInHierarchy): self
+    {
+        return new self(
+            (string) $method->getDocComment(),
+            true,
+            self::extractAnnotationsFromReflector($method),
+            $method->getStartLine(),
+            $method->getEndLine(),
+            $method->getFileName(),
+            $method->getName(),
+            $classNameInHierarchy
+        );
+    }
+
+    /**
+     * Note: we do not preserve an instance of the reflection object, since it cannot be safely (de-)serialized.
+     *
+     * @param string $docComment
+     * @param bool $isMethod
+     * @param array<string, array<int, string>> $symbolAnnotations
+     * @param int $startLine
+     * @param int $endLine
+     * @param string $fileName
+     * @param string $name
+     * @param string $className
+     */
+    private function __construct(
+        string $docComment,
+        bool $isMethod,
+        array $symbolAnnotations,
+        int $startLine,
+        int $endLine,
+        string $fileName,
+        string $name,
+        string $className
+    ) {
+        $this->docComment        = $docComment;
+        $this->isMethod          = $isMethod;
+        $this->symbolAnnotations = $symbolAnnotations;
+        $this->startLine         = $startLine;
+        $this->endLine           = $endLine;
+        $this->fileName          = $fileName;
+        $this->name              = $name;
+        $this->className         = $className;
+    }
+
+    /**
+     * @psalm-return array<string, array{line: int, value: string}>
+     */
+    public function getInlineAnnotations(): array
+    {
+        $code        = file($this->fileName);
+        $lineNumber  = $this->startLine;
+        $startLine   = $this->startLine - 1;
+        $endLine     = $this->endLine - 1;
+        $codeLines   = array_slice($code, $startLine, $endLine - $startLine + 1);
+        $annotations = [];
+
+        foreach ($codeLines as $line) {
+            if (preg_match('#/\*\*?\s*@(?P<name>[A-Za-z_-]+)(?:[ \t]+(?P<value>.*?))?[ \t]*\r?\*/$#m', $line, $matches)) {
+                $annotations[strtolower($matches['name'])] = [
+                    'line'  => $lineNumber,
+                    'value' => $matches['value'],
+                ];
+            }
+
+            $lineNumber++;
+        }
+
+        return $annotations;
+    }
+
+    public function symbolAnnotations(): array
+    {
+        return $this->symbolAnnotations;
+    }
+
+    /**
+     * @param string $docBlock
+     * @return array<string, array<int, string>>
+     */
+    private static function parseDocBlock(string $docBlock): array
+    {
+        // Strip away the docblock header and footer to ease parsing of one line annotations
+        $docBlock    = (string) substr($docBlock, 3, -2);
+        $annotations = [];
+
+        if (preg_match_all('/@(?P<name>[A-Za-z_-]+)(?:[ \t]+(?P<value>.*?))?[ \t]*\r?$/m', $docBlock, $matches)) {
+            $numMatches = count($matches[0]);
+
+            for ($i = 0; $i < $numMatches; $i++) {
+                $annotations[$matches['name'][$i]][] = (string) $matches['value'][$i];
+            }
+        }
+
+        return $annotations;
+    }
+
+    /** 
+     * @param ReflectionClass|ReflectionFunctionAbstract $reflector 
+     * @return array
+     */
+    private static function extractAnnotationsFromReflector(Reflector $reflector): array
+    {
+        $annotations = [];
+
+        if ($reflector instanceof ReflectionClass) {
+            $annotations = array_merge(
+                $annotations,
+                ...array_map(
+                    static function (ReflectionClass $trait): array {
+                        return self::parseDocBlock((string) $trait->getDocComment());
+                    },
+                    array_values($reflector->getTraits())
+                )
+            );
+        }
+
+        return array_merge(
+            $annotations,
+            self::parseDocBlock((string) $reflector->getDocComment())
+        );
+    }
+}

--- a/src/Annotation/Registry.php
+++ b/src/Annotation/Registry.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace FriendsOfPhpSpec\PhpSpec\CodeCoverage\Annotation;
+
+use function array_key_exists;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionMethod;
+
+/**
+ * Reflection information, and therefore DocBlock information, is static within
+ * a single PHP process. It is therefore okay to use a Singleton registry here.
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class Registry
+{
+    /**
+     * @var array<string, DocBlock> indexed by class name
+     */
+    private $classDocBlocks = [];
+
+    /**
+     * @var array<string, array<string, DocBlock>> indexed by class name and method name
+     */
+    private $methodDocBlocks = [];
+
+    /**
+     * @param string $class
+     * @return DocBlock
+     * @throws ReflectionException
+     */
+    public function forClassName(string $class): DocBlock
+    {
+        if (array_key_exists($class, $this->classDocBlocks)) {
+            return $this->classDocBlocks[$class];
+        }
+
+        $reflection = new ReflectionClass($class);
+
+        return $this->classDocBlocks[$class] = DocBlock::ofClass($reflection);
+    }
+
+    /**
+     * @param string $classInHierarchy
+     * @param string $method
+     * @return DocBlock
+     * @throws ReflectionException
+     */
+    public function forMethod(string $classInHierarchy, string $method): DocBlock
+    {
+        if (isset($this->methodDocBlocks[$classInHierarchy][$method])) {
+            return $this->methodDocBlocks[$classInHierarchy][$method];
+        }
+
+        $reflection = new ReflectionMethod($classInHierarchy, $method);
+
+        return $this->methodDocBlocks[$classInHierarchy][$method] = DocBlock::ofMethod($reflection, $classInHierarchy);
+    }
+}

--- a/src/Exception/CodeCoverageException.php
+++ b/src/Exception/CodeCoverageException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FriendsOfPhpSpec\PhpSpec\CodeCoverage\Exception;
+
+class CodeCoverageException extends \Exception
+{
+}

--- a/src/Exception/InvalidCoversTargetException.php
+++ b/src/Exception/InvalidCoversTargetException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FriendsOfPhpSpec\PhpSpec\CodeCoverage\Exception;
+
+class InvalidCoversTargetException extends CodeCoverageException
+{
+}


### PR DESCRIPTION
Implements #46 

It's a PoC to see if it's way we want to add support for `@covers`. It actually works but of course the code needs more work and we need tests.

I pulled in the code-unit package and grabbed the code which is needed from the PHPUnit framework to support the `@covers` functionality. I think it's better than requiring the whole phpunit/phpunit framework just to get covers annotation support when actually only a few hundred lines of code are required.