### PR TITLE
Add Minimum Coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ extensions:
     # Blacklist files for which code generation should NOT be done
     #blacklist_files:
       #- lib/bootstrap.php
+    #
+    # Require minimum code coverage (in percent - e.g., 91.15)
+    #min_coverage: 100
 ```
 
 ### Options

--- a/spec/Exception/LowCoverageRatioExceptionSpec.php
+++ b/spec/Exception/LowCoverageRatioExceptionSpec.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\FriendsOfPhpSpec\PhpSpec\CodeCoverage\Exception;
+
+use FriendsOfPhpSpec\PhpSpec\CodeCoverage\Exception\LowCoverageRatioException;
+use PhpSpec\ObjectBehavior;
+use RuntimeException;
+
+/**
+ * @mixin LowCoverageRatioException
+ */
+class LowCoverageRatioExceptionSpec extends ObjectBehavior
+{
+    public function it_should_be_a_RuntimeException()
+    {
+        $this->shouldHaveType(RuntimeException::class);
+    }
+}

--- a/spec/Listener/CodeCoverageRatioListenerSpec.php
+++ b/spec/Listener/CodeCoverageRatioListenerSpec.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\FriendsOfPhpSpec\PhpSpec\CodeCoverage\Listener;
+
+use FriendsOfPhpSpec\PhpSpec\CodeCoverage\Exception\LowCoverageRatioException;
+use FriendsOfPhpSpec\PhpSpec\CodeCoverage\Listener\CodeCoverageRatioListener;
+use PhpSpec\Event\SuiteEvent;
+use PhpSpec\ObjectBehavior;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\Driver\Driver;
+use SebastianBergmann\CodeCoverage\Filter;
+use SebastianBergmann\CodeCoverage\RawCodeCoverageData;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @mixin CodeCoverageRatioListener
+ */
+class CodeCoverageRatioListenerSpec extends ObjectBehavior
+{
+    /**
+     * @var CodeCoverage
+     */
+    private $coverage;
+
+    public function it_is_an_event_subscriber()
+    {
+        $this->shouldHaveType(EventSubscriberInterface::class);
+    }
+
+    public function it_should_subscribe_to_after_suite_event_with_least_priority()
+    {
+        $this->getSubscribedEvents()->shouldBe([
+            'afterSuite' => ['afterSuite', -1000],
+        ]);
+    }
+
+    public function it_should_throw_an_error_if_the_minimum_coverage_is_not_met(SuiteEvent $event)
+    {
+        $this->beConstructedWith(
+            $coverage = new CodeCoverage($this->createDriverStub(5, 5), new Filter()),
+            75.0
+        );
+        $coverage->start('acme-foobar');
+        $coverage->stop();
+
+        $this->shouldThrow(LowCoverageRatioException::class)->during('afterSuite', [$event]);
+    }
+
+    public function let()
+    {
+        $this->beConstructedWith(
+            $this->coverage = new CodeCoverage($this->createDriverStub(1), new Filter()),
+            100
+        );
+    }
+
+    /**
+     * @param mixed $coveredCount
+     * @param mixed $uncoveredCount
+     */
+    private function createDriverStub($coveredCount, $uncoveredCount = 0): Driver
+    {
+        return new class($coveredCount, $uncoveredCount) extends Driver {
+            /**
+             * @var int
+             */
+            private $coveredCount;
+
+            /**
+             * @var int
+             */
+            private $uncoveredCount;
+
+            public function __construct($coveredCount, $uncoveredCount = 0)
+            {
+                $this->coveredCount = $coveredCount;
+                $this->uncoveredCount = $uncoveredCount;
+            }
+
+            public function nameAndVersion(): string
+            {
+                return 'DriverStub';
+            }
+
+            public function start(): void
+            {
+            }
+
+            public function stop(): RawCodeCoverageData
+            {
+                $rawCoverage = [
+                    __FILE__ => array_fill(10, $this->coveredCount, 1)
+                        + array_fill(10 + $this->coveredCount, $this->uncoveredCount, -1),
+                ];
+
+                return RawCodeCoverageData::fromXdebugWithoutPathCoverage($rawCoverage);
+            }
+        };
+    }
+}

--- a/spec/Listener/NullListenerSpec.php
+++ b/spec/Listener/NullListenerSpec.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\FriendsOfPhpSpec\PhpSpec\CodeCoverage\Listener;
+
+use FriendsOfPhpSpec\PhpSpec\CodeCoverage\Listener\NullListener;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @mixin NullListener
+ */
+class NullListenerSpec extends ObjectBehavior
+{
+    public function it_is_an_event_subscriber()
+    {
+        $this->shouldHaveType(EventSubscriberInterface::class);
+    }
+
+    public function it_should_not_subscribe_to_any_events()
+    {
+        $this->getSubscribedEvents()->shouldBe([]);
+    }
+}

--- a/src/Exception/LowCoverageRatioException.php
+++ b/src/Exception/LowCoverageRatioException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FriendsOfPhpSpec\PhpSpec\CodeCoverage\Exception;
+
+use RuntimeException;
+
+class LowCoverageRatioException extends RuntimeException
+{
+}

--- a/src/Listener/CodeCoverageRatioListener.php
+++ b/src/Listener/CodeCoverageRatioListener.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FriendsOfPhpSpec\PhpSpec\CodeCoverage\Listener;
+
+use FriendsOfPhpSpec\PhpSpec\CodeCoverage\Exception\LowCoverageRatioException;
+use PhpSpec\Event\SuiteEvent;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\ProcessedCodeCoverageData;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+use function count;
+
+final class CodeCoverageRatioListener implements EventSubscriberInterface
+{
+    /**
+     * @var CodeCoverage
+     */
+    private $coverage;
+
+    /**
+     * @var float
+     */
+    private $minimumCoverage;
+
+    /**
+     * CodeCoverageRatioListener constructor.
+     *
+     * @param float $minimumCoverage
+     */
+    public function __construct(CodeCoverage $coverage, $minimumCoverage)
+    {
+        $this->coverage = $coverage;
+        $this->minimumCoverage = (float) $minimumCoverage;
+    }
+
+    public function afterSuite(SuiteEvent $event): void
+    {
+        $actualCoverageRatio = $this->simplifyRatio($this->calculateRatio($this->coverage->getData()));
+
+        if ($actualCoverageRatio < $this->minimumCoverage) {
+            throw new LowCoverageRatioException(sprintf(
+                'Test suites only cover %1.02f%% of the required %1.02f%% minimum coverage',
+                $actualCoverageRatio,
+                $this->minimumCoverage
+            ));
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            'afterSuite' => ['afterSuite', -1000],
+        ];
+    }
+
+    /**
+     * @return float
+     */
+    private function calculateRatio(ProcessedCodeCoverageData $coverageData)
+    {
+        return $this->calculateRatioForEachFiles($coverageData->lineCoverage());
+    }
+
+    /**
+     * @param array<string, array> $lineCoverage
+     * @param float $initialRatio
+     *
+     * @return float
+     */
+    private function calculateRatioForEachFiles(array $lineCoverage, $initialRatio = 0.0)
+    {
+        if ($lines = array_shift($lineCoverage)) {
+            $ratio = $this->calculateRatioForEachFiles($lineCoverage, count(array_filter($lines)) / count($lines));
+        }
+
+        return $ratio ?? $initialRatio;
+    }
+
+    /**
+     * @param float $ratio
+     *
+     * @return float
+     */
+    private function simplifyRatio($ratio)
+    {
+        return (ceil($ratio * 10000) / 10000) * 100;
+    }
+}

--- a/src/Listener/NullListener.php
+++ b/src/Listener/NullListener.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FriendsOfPhpSpec\PhpSpec\CodeCoverage\Listener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class NullListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
As a developer using [PhpSpec](https://github.com/phpspec/phpspec)
[In order get developers' attention and reduce the Broken Windows effect](https://dzone.com/articles/why-you-should-enforce-100-code-coverage)
I need a `min_coverage` constraint