### PR TITLE
Add compatibility with PHPUnit 10.

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -4,19 +4,11 @@ on:
   - pull_request
   - push
 
-name: "Continuous Integration"
+name: "Test Coverage"
 
 jobs:
   run:
-    runs-on: ${{ matrix.operating-system }}
-    strategy:
-      fail-fast: true
-      matrix:
-        operating-system: [ubuntu-latest, windows-latest, macOS-latest]
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
-        composer-versions: ['composer:v1', 'composer:v2']
-        dependencies: ["lowest", "highest"]
-
+    runs-on: ubuntu-latest
     steps:
       - name: Set git to use LF
         run: |
@@ -31,9 +23,8 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
-          tools: ${{ matrix.composer-versions }}
-          extensions: xdebug
+          php-version: 8.1
+          extensions: pcov
 
       - name: Get Composer Cache Directory
         id: composer-cache
@@ -48,11 +39,11 @@ jobs:
 
       - name: "Install dependencies"
         uses: "ramsey/composer-install@v2"
-        with:
-          dependency-versions: "${{ matrix.dependencies }}"
 
       - name: Run tests
-        run: |
-          composer run analyse
-          composer run lint
-          composer run test
+        run: composer run test-coverage
+
+      - name: Upload Scrutinizer coverage
+        uses: sudo-bot/action-scrutinizer@latest
+        with:
+          cli-args: "--format=php-clover coverage/clover.xml"

--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,8 @@
     "scripts": {
         "analyse": "phpstan analyse --level 8 src",
         "lint": "php-cs-fixer fix --dry-run src && php-cs-fixer fix --dry-run spec",
-        "test": "phpspec run"
+        "test": "phpspec run --no-coverage",
+        "test-coverage": "phpspec run"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "require": {
         "php": ">= 7.3",
         "phpspec/phpspec": "^6.0 || ^7.0",
-        "phpunit/php-code-coverage": "^9.0"
+        "phpunit/php-code-coverage": "^9.2 || ^10.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.5",

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         ]
     },
     "scripts": {
-        "analyse": "phpstan analyse --level 8 src",
+        "analyse": "phpstan analyse",
         "lint": "php-cs-fixer fix --dry-run src && php-cs-fixer fix --dry-run spec",
         "test": "phpspec run --no-coverage",
         "test-coverage": "phpspec run"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,10 @@
+parameters:
+    level: 8
+    reportUnmatchedIgnoredErrors: false
+    paths:
+        - src
+    ignoreErrors:
+        # phpstan has hard time to check whenever we are using PHPUnit 10 or PHPUnit 9
+        -
+            message: '#Class SebastianBergmann\\CodeCoverage\\Report\\Text constructor invoked with 4 parameters, 1-3 required\.#'
+            path: ./src/CodeCoverageExtension.php

--- a/spec/Listener/CodeCoverageListenerSpec.php
+++ b/spec/Listener/CodeCoverageListenerSpec.php
@@ -12,7 +12,6 @@ use PhpSpec\ObjectBehavior;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Driver\Driver;
 use SebastianBergmann\CodeCoverage\Filter;
-use SebastianBergmann\CodeCoverage\RawCodeCoverageData;
 use stdClass;
 
 /**
@@ -26,6 +25,13 @@ use stdClass;
  */
 class CodeCoverageListenerSpec extends ObjectBehavior
 {
+    public function let(ConsoleIO $io, Driver $driver)
+    {
+        $codeCoverage = new CodeCoverage($driver->getWrappedObject(), new Filter());
+
+        $this->beConstructedWith($io, $codeCoverage, []);
+    }
+
     public function it_can_process_all_directory_filtering_options(SuiteEvent $event)
     {
         $this->setOptions([
@@ -84,29 +90,5 @@ class CodeCoverageListenerSpec extends ObjectBehavior
         $this
             ->shouldThrow(ConfigurationException::class)
             ->during('beforeSuite', [$event]);
-    }
-
-    public function let(ConsoleIO $io)
-    {
-        $codeCoverage = new CodeCoverage(new DriverStub(), new Filter());
-
-        $this->beConstructedWith($io, $codeCoverage, []);
-    }
-}
-
-class DriverStub extends Driver
-{
-    public function nameAndVersion(): string
-    {
-        return 'DriverStub';
-    }
-
-    public function start(bool $determineUnusedAndDead = true): void
-    {
-    }
-
-    public function stop(): RawCodeCoverageData
-    {
-        return RawCodeCoverageData::fromXdebugWithoutPathCoverage([]);
     }
 }

--- a/src/CodeCoverageExtension.php
+++ b/src/CodeCoverageExtension.php
@@ -24,6 +24,7 @@ use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Driver\Selector;
 use SebastianBergmann\CodeCoverage\Filter;
 use SebastianBergmann\CodeCoverage\Report;
+use SebastianBergmann\CodeCoverage\Report\Thresholds;
 use SebastianBergmann\CodeCoverage\Version;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -119,12 +120,18 @@ class CodeCoverageExtension implements Extension
 
                         break;
                     case 'text':
-                        $reports['text'] = new Report\Text(
-                            $options['lower_upper_bound'],
-                            $options['high_lower_bound'],
-                            $options['show_uncovered_files'],
-                            $options['show_only_summary']
-                        );
+                        $reports['text'] = version_compare(Version::id(), '10.0.0', '>=') && class_exists(Thresholds::class)
+                            ? new Report\Text(
+                                Thresholds::from($options['lower_upper_bound'], $options['high_lower_bound']),
+                                $options['show_uncovered_files'],
+                                $options['show_only_summary']
+                            )
+                            : new Report\Text(
+                                $options['lower_upper_bound'],
+                                $options['high_lower_bound'],
+                                $options['show_uncovered_files'],
+                                $options['show_only_summary']
+                            );
 
                         break;
                     case 'xml':

--- a/src/CodeCoverageExtension.php
+++ b/src/CodeCoverageExtension.php
@@ -159,14 +159,9 @@ class CodeCoverageExtension implements Extension
         });
 
         $container->define('event_dispatcher.listeners.code_coverage', static function (ServiceContainer $container) {
-            $skipCoverage = false;
-
             /** @var InputInterface $input */
             $input = $container->get('console.input');
-
-            if ($input->hasOption('no-coverage') && $input->getOption('no-coverage')) {
-                $skipCoverage = true;
-            }
+            $skipCoverage = $input->hasOption('no-coverage') && $input->getOption('no-coverage');
 
             /** @var ConsoleIO $consoleIO */
             $consoleIO = $container->get('console.io');


### PR DESCRIPTION
We rely on `phpunit/php-code-coverage`, which now has a version 10. Since API haven't changed regarding our usage, we are compatible with both version 9 and 10.

Also this PR change different things:

* A new action was added to transmit the code coverage to scrutinizer to optimize the process duration for the tests ;
* No more coverage computed on every test, only when we want to compute it ;
* Cleanup the specs (remove DriverStub and use a Mock instead) ;
* Found that we are note compatible with phpunit/php-code-coverage < 9.2.0, the was reflected in the composer.json file ;
* A custom phpstan configuration file was added to skip an error related to a constructor misunderstanding (I tried to do different things but can't find another way to fix this) ;
* All the test are now executed on lower and higher possible composer packages version to ensure the version constraints are met.