### PR TITLE
Execute tests against PHP8.3 and allow compatibility with phpunit/php-code-coverage v11.*

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macOS-latest]
-        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
         composer-versions: ['composer:v1', 'composer:v2']
         dependencies: ["lowest", "highest"]
 


### PR DESCRIPTION
Just updated the CI configuration to test against PHP8.3 and refine some composer dependencies rules.