### PR TITLE
Blacklist: Fix building of the excludes list

### DIFF
--- a/src/Listener/CodeCoverageListener.php
+++ b/src/Listener/CodeCoverageListener.php
@@ -154,15 +154,19 @@ class CodeCoverageListener implements EventSubscriberInterface
         foreach ($this->options['blacklist'] as $option) {
             $settings = $this->filterDirectoryParams($option);
             if (!empty($settings['suffix']) || !empty($settings['prefix'])) {
-                $excludes = $excludes + (new FileIteratorFacade())->getFilesAsArray(
-                    $settings['directory'],
-                    $settings['suffix'],
-                    $settings['prefix']
+                $excludes = array_merge(
+                    $excludes,
+                    (new FileIteratorFacade())->getFilesAsArray(
+                        $settings['directory'],
+                        $settings['suffix'],
+                        $settings['prefix']
+                    )
                 );
             } else {
                 $excludes[] = $settings['directory'];
             }
         }
+        $excludes = array_unique($excludes);
 
         foreach ($this->options['whitelist'] as $option) {
             $settings = $this->filterDirectoryParams($option);


### PR DESCRIPTION
Reason: The "+" operator compares keys from two arrays, which, while building the excludes list, results in some paths being skipped.
Implementation: Replaced array union operator with simple array_merge. Unfortunately, this approach might generate duplicate paths, so an array_unique call was added.
Side effects: None.