### PR TITLE
Remove support for Composer v1 during CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macOS-latest]
         php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
-        composer-versions: ['composer:v1', 'composer:v2']
+        composer-versions: ['composer:v2']
         dependencies: ["lowest", "highest"]
 
     steps:


### PR DESCRIPTION
Since the Composer v1 shutdown announce we needed to move away from Composer v1.

Now the deadline has been reached: https://blog.packagist.com/shutting-down-packagist-org-support-for-composer-1-x/#key-dates

I chose to drop the composer v1 from the CI.